### PR TITLE
Remove Default from ObjectID

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,13 +4,13 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 #[cfg(not(feature="parallel"))]
-pub trait ObjectID: Copy + Clone + Default + Hash + Ord + Debug {}
+pub trait ObjectID: Copy + Clone + Hash + Ord + Debug {}
 
 #[cfg(not(feature="parallel"))]
-impl<T: Copy + Clone + Default + Hash + Ord + Debug> ObjectID for T {}
+impl<T: Copy + Clone + Hash + Ord + Debug> ObjectID for T {}
 
 #[cfg(feature="parallel")]
-pub trait ObjectID: Copy + Clone + Default + Hash + Ord + Send + Sync + Debug {}
+pub trait ObjectID: Copy + Clone + Hash + Ord + Send + Sync + Debug {}
 
 #[cfg(feature="parallel")]
-impl<T: Copy + Clone + Default + Hash + Ord + Send + Sync + Debug> ObjectID for T {}
+impl<T: Copy + Clone + Hash + Ord + Send + Sync + Debug> ObjectID for T {}


### PR DESCRIPTION
Implementing ObjectID requires Default. However, a default entity usually doesn't make any sense. `specs::Entity` or `hecs::Entity`, for example, don't implement Default for this reason and therefore can't be used. Luckily, it seems like this requirement can simply be removed.

Is there any reason for this that I've missed?